### PR TITLE
Fixed bugs in final plot routines

### DIFF
--- a/DepletionExtrapolation1.py
+++ b/DepletionExtrapolation1.py
@@ -390,7 +390,7 @@ def main():
             print('creating {}'.format(filename))
             with open(outputfilename, 'a') as outputfile:
                 outputfile.write('\n')
-                if extrap_plot == 1:
+                if kval == 0:
                     outputfile.write(
                         'Extrapolating based on last 5% of data = Final Absorbance'
                         + '\n')
@@ -412,8 +412,7 @@ def main():
             #
             if final_abs_flag == "true":
                 for i in range(loopcount):
-                    substrate[i] = 1 - (starting_abs[i] - absdata[0]) / (
-                        init_abs2 + deltaAf)
+                    substrate[i] = 1 - (starting_abs[i] - absdata[0]) / (init_abs2 + deltaAf - absdata[0])
     #
     print("PROGRAM COMPLETE")
 

--- a/input_output.py
+++ b/input_output.py
@@ -15,7 +15,7 @@ def initial_setup(config_file=None, interactive=True):
     print(
         "Data will be written to a file having the same name as the data file, "
     )
-    print("but with _Analysis.txt at then end.")
+    print("but with _Analysis.txt at the end.")
     name = input(
         "Enter the filename of the data file (it should end in .txt): ")
     print()
@@ -175,7 +175,7 @@ def final_plot(dt):
     ax = AA.Subplot(fig, 1, 1, 1)
     fig.add_subplot(ax)
     #
-    if dt.kval == 1:
+    if dt.kval == 0:
         plot_title = dt.name[:-4] + " -- Extrapolation plot, based on last 5% of data = final absorbance"
     else:
         plot_title = dt.name[:-4] + " -- Extrapolation plot, based on fit final absorbance"


### PR DESCRIPTION
When doing more than one final plot (due to the final absorbance from the last 5% of data and the fit being off by more than 0.1%) the substrate concentrations were being incorrectly calculated.
The title for the final plots were also being constructed incorrectly.